### PR TITLE
Unexisting Fail method as example on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ func init() {
 
 	Then(`^the user should be successfully logged in$`, func() {
 		if !userIsLoggedIn() {
-			T.Fail("user should have been logged in")
+			T.Errorf("user should have been logged in")
 		}
 	})
 }


### PR DESCRIPTION
When you execute the current README example it becomes on a compilation error:

```
gucumber.T.Fail undefined (type gucumber.Tester has no field or method Fail)
```

Following the API docs seems Errorf is the correct method to be called.
