### PR TITLE
Adding support for composite GOPATHs with symlinks

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -100,14 +100,15 @@ func buildAndRunDir(dir string, filters []string, goBuildTags string) error {
 func assembleImportPath(file string) string {
 	a, _ := filepath.Abs(filepath.Dir(file))
 	absPath, fullPkg := filepath.ToSlash(a), ""
+	greedy := 0
 	for _, p := range filepath.SplitList(os.Getenv("GOPATH")) {
 		a, _ = filepath.Abs(p)
 		p = filepath.ToSlash(a)
-		if strings.HasPrefix(absPath, p) {
+		symlink, _ := filepath.EvalSymlinks(p)
+		if (strings.HasPrefix(absPath, p) || strings.HasPrefix(absPath, symlink)) && len(p) > greedy {
 			prefixPath := filepath.ToSlash(filepath.Join(p, "src"))
-			rpath, _ := filepath.Rel(prefixPath, absPath)
-			fullPkg = filepath.ToSlash(rpath)
-			break
+			fullPkg, _ = filepath.Rel(prefixPath, absPath)
+			greedy = len(p)
 		}
 	}
 	return fullPkg

--- a/builder_test.go
+++ b/builder_test.go
@@ -11,9 +11,12 @@ import (
 func TestPackageImportPathIsExtractedFromFilePath(t *testing.T) {
 	//arrange
 	packageName := "github.com/username/reponame"
-	file := filepath.Join(os.Getenv("GOPATH"), "src/github.com/username/reponame/main.go")
-	//act
-	importPath := assembleImportPath(file)
-	//assert
-	assert.Equal(t, packageName, importPath)
+	gopath := os.Getenv("GOPATH")
+	for _, p := range filepath.SplitList(gopath) {
+		file := filepath.Join(p, "src/github.com/username/reponame/main.go")
+		//act
+		importPath := assembleImportPath(file)
+		//assert
+		assert.Equal(t, packageName, importPath)
+	}
 }


### PR DESCRIPTION
This change takes into account composite `GOPATH`s and finds the best matched import path based on import path length. To ensure we pass the unit test, `builder_test.go`, we need to best match, rather than on the first find.

Issue: symlinks in `GOPATH` would fail, IF the symlink is within other `GOPATH`s.
Fix: Use a greedy algorithm to find the best match.