### PR TITLE
Add limited support for go modules

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,6 +1,7 @@
 package gucumber
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -94,10 +95,30 @@ func buildAndRunDir(dir string, filters []string, goBuildTags string) error {
 	return nil
 }
 
+func goMod() string {
+	if _, err := os.Stat("go.mod"); os.IsNotExist(err) {
+		return ""
+	}
+	file, err := os.Open("go.mod")
+	defer file.Close()
+	if err != nil {
+		panic(err)
+	}
+	line, err := bufio.NewReader(file).ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+	return string(line[7 : len(line)-1])
+}
+
 // ToSlash is being used to coerce the different
 // os PathSeparators into the forward slash
 // as the forward slash is required by Go's import statement
 func assembleImportPath(file string) string {
+	module := goMod()
+	if module != "" {
+		return filepath.ToSlash(filepath.Join(module, filepath.Dir(file)))
+	}
 	a, _ := filepath.Abs(filepath.Dir(file))
 	absPath, fullPkg := filepath.ToSlash(a), ""
 	greedy := 0


### PR DESCRIPTION
To support go 1.11.

This fixes this error:

> panic: could not determine package path for internal/features/basic/step_definitions.go

In packages that use go modules by reading the module name from the go.mod file.